### PR TITLE
Fixed PendulumMDP Float32 loss errors

### DIFF
--- a/src/extra/pendulum.jl
+++ b/src/extra/pendulum.jl
@@ -91,7 +91,7 @@ function POMDPs.observation(mdp::PendulumPOMDP, s)
 end
 
 function POMDPs.initialstate(mdp::PendulumPOMDP)
-    ImplicitDistribution((rng) -> [rand(rng, mdp.θ0), rand(rng, mdp.ω0)])
+    ImplicitDistribution((rng) -> Float32.([rand(rng, mdp.θ0), rand(rng, mdp.ω0)]))
 end
 
 POMDPs.initialobs(mdp::PendulumPOMDP, s) = observation(mdp, s)
@@ -134,7 +134,7 @@ function POMDPs.gen(mdp::PendulumMDP, s, a, rng::AbstractRNG = Random.GLOBAL_RNG
 end
 
 function POMDPs.initialstate(mdp::PendulumMDP)
-    ImplicitDistribution((rng) -> [rand(rng, mdp.θ0), rand(rng, mdp.ω0)])
+    ImplicitDistribution((rng) -> Float32.([rand(rng, mdp.θ0), rand(rng, mdp.ω0)]))
 end
 
 POMDPs.actions(mdp::PendulumMDP) = mdp.actions


### PR DESCRIPTION
The `PendulumMDP` failed to learn due to a bunch of "Float64 loss found" errors, yet the `PendulumPOMDP` had no issues—the culprit was because the POMDP uses `initialobs` which converts the observation to `Float32` but the MDP version failed to do so in the `initialstate` function.

I added the `Float32.(...)` broadcasting for both the POMDP and MDP version (for consistency).