### PR TITLE
Export gym interface functions and handle `isterminal` when not a timed-based environment

### DIFF
--- a/src/POMDPGym.jl
+++ b/src/POMDPGym.jl
@@ -20,7 +20,7 @@ module POMDPGym
     
     include("pycalls.jl")
     
-    export GymPOMDP, render, init_mujoco_render
+    export GymPOMDP, reset!, step!, finished, render, close, init_mujoco_render
     include("gym_pomdp.jl")
     
     export torgb, preproc_atari_frame, AtariPOMDP

--- a/src/gym_pomdp.jl
+++ b/src/gym_pomdp.jl
@@ -37,9 +37,12 @@ function POMDPs.isterminal(mdp::GymPOMDP, s)
     try
         mdp.env.pyenv._elapsed_steps >= mdp.env.pyenv._max_episode_steps && return false
     catch
-        mdp.env.pyenv.num_steps >= mdp.env.pyenv.steps && return false
+        try
+            mdp.env.pyenv.num_steps >= mdp.env.pyenv.steps && return false
+        catch
+            return mdp.env.done
+        end
     end
-    mdp.env.done
 end
 POMDPs.discount(mdp::GymPOMDP) = mdp.γ
 


### PR DESCRIPTION
^ title.