### PR TITLE
Removed error for environments that use `done`

### DIFF
--- a/src/gym_pomdp.jl
+++ b/src/gym_pomdp.jl
@@ -85,7 +85,7 @@ function check_exceeds_steps(mdp)
             return
         end
     else
-        @error "Couldn't determine if max steps reached"
+        return
     end
 end
     


### PR DESCRIPTION
As requested in https://github.com/ancorso/POMDPGym.jl/commit/2446b32d30d1e9368564b18116595bc915dbfa95#commitcomment-84440963